### PR TITLE
AP-5743: Copied/pasted from the old vendor stuff

### DIFF
--- a/src/Apruve/LineItem.php
+++ b/src/Apruve/LineItem.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Apruve;
+
+require_once 'ApruveObject.php';
+
+class LineItem extends ApruveObject {
+
+  var $id;
+  var $payment_request_id;
+  var $title;
+  var $plan_code;
+  var $amount_cents;
+  var $quantity;
+  var $price_ea_cents;
+  var $merchant_notes;
+  var $description;
+  var $variant_info;
+  var $sku;
+  var $vendor;
+  var $view_product_url;
+
+  protected static $hash_order = [
+    'title',
+    'plan_code',
+    'amount_cents',
+    'price_ea_cents',
+    'quantity',
+    'merchant_notes',
+    'description',
+    'variant_info', 
+    'sku',
+    'vendor', 
+    'view_product_url',
+  ];
+
+  protected static $json_fields = [
+    'payment_request_id',
+    'title',
+    'plan_code',
+    'amount_cents',
+    'price_ea_cents',
+    'quantity',
+    'merchant_notes',
+    'description',
+    'variant_info', 
+    'sku',
+    'vendor', 
+    'view_product_url',
+  ];
+}

--- a/src/Apruve/PaymentRequest.php
+++ b/src/Apruve/PaymentRequest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Apruve;
+
+require_once 'ApruveObject.php';
+
+class PaymentRequest extends ApruveObject
+{
+  protected static $PAYMENT_REQUESTS_PATH = '/payment_requests/';
+  private static $FINALIZE_PATH = '/payment_requests/%s/finalize';
+
+  var $id;
+  var $merchant_id;
+  var $username;
+  var $status;
+  var $merchant_order_id;
+  var $amount_cents;
+  var $tax_cents;
+  var $shipping_cents;
+  var $currency;
+  var $expire_at;
+  var $line_items = [];
+  var $api_url;
+  var $view_url;
+  var $created_at;
+  var $updated_at;
+
+  protected static $hash_order = [
+    'merchant_id',
+    'merchant_order_id',
+    'amount_cents',
+    'currency',
+    'tax_cents',
+    'shipping_cents',
+    'expire_at',
+  ];
+
+  protected static $json_fields = [
+    'id',
+    'merchant_id',
+    'merchant_order_id',
+    'amount_cents',
+    'currency',
+    'tax_cents',
+    'shipping_cents',
+    'expire_at',
+    'line_items',
+  ];
+
+  public function __construct($payment_request=[], $client=null)
+  {
+    if (array_key_exists('line_items', $payment_request))
+    {
+      foreach($payment_request['line_items'] as $key => $line_item)
+      {
+        if (is_array($line_item))
+        {
+          $payment_request['line_items'][$key] = new LineItem($line_item);
+        }
+      }
+    }
+
+    parent::__construct($payment_request, $client);
+  }
+
+  public function setShippingCents($shipping_cents)
+  {
+    $this->shipping_cents = $shipping_cents;
+  }
+
+  public function setTaxCents($tax_cents)
+  {
+    $this->tax_cents = $tax_cents;
+  }
+
+  public function setAmountCents($amount_cents)
+  {
+    $this->amount_cents = $amount_cents;
+  }
+
+  public function setMerchantOrderId($merchant_order_id)
+  {
+    $this->merchant_order_id = $merchant_order_id;
+  }
+
+  public function setExpireAt($expire_at)
+  {
+    $this->expire_at = $expire_at;
+  }
+
+  public function toSecureString()
+  {
+    $hashString = $this->toHashString();
+    foreach($this->line_items as $line_item)
+    {
+      $hashString .= $line_item->toHashString();
+    }
+    return $hashString;
+  }
+     
+
+  public function toSecureHash() 
+  {
+    $apiKey = $this->client->getApiKey();
+    return hash("sha256", $apiKey.$this->toSecureString());
+  }
+
+  public function addLineItem($line_item)
+  {
+    if (get_class($line_item) == 'Apruve\LineItem')
+    {
+      return array_push($this->line_items, $line_item);
+    }
+    else
+    {
+      return false;
+    }
+  }
+
+  public static function get($payment_request_id, $client=null)
+  {
+    if ($client == null)
+    {
+      $client = new Client();
+    }
+    $response = $client->get(self::$PAYMENT_REQUESTS_PATH.$payment_request_id);
+
+    if ($response[0] == 200)
+    {
+      $object = new self($response[1], $client);
+      return $object;
+    }
+    else
+    {
+      return $response[2];
+    }
+  }
+
+  public function update()
+  {
+    $response = $this->client->put(self::$PAYMENT_REQUESTS_PATH.$this->id,
+      $this->toJson());
+    return $response[0] == 200;
+  }
+
+  
+
+}


### PR DESCRIPTION
This totally may not be what is going on, but it looks to me like these two files were just forgotten when moved the vendor stuff?

Errors that I was getting:
```
Uncaught Error: Class 'Apruve\PaymentRequest' not found in /Users/tommycrumrine/wp/wp-content/plugins/apruve-woocommerce-master/classes/apruve_gateway.php:208
Stack trace:
#0 /Users/tommycrumrine/wp/wp-content/plugins/woocommerce/templates/checkout/payment-method.php(31): Apruve_Gateway->payment_fields()
#1 /Users/tommycrumrine/wp/wp-content/plugins/woocommerce/includes/wc-core-functions.php(205): include('/Users/tommycru...')
#2 /Users/tommycrumrine/wp/wp-content/plugins/woocommerce/templates/checkout/payment.php(32): wc_get_template('checkout/paymen...', Array)
#3 /Users/tommycrumrine/wp/wp-content/plugins/woocommerce/includes/wc-core-functions.php(205): include('/Users/tommycru...')
#4 /Users/tommycrumrine/wp/wp-content/plugins/woocommerce/includes/wc-template-functions.php(1615): wc_get_template('checkout/paymen...', Array)
#5 /Users/tommycrumrine/wp/wp-includes/class-wp-hook.php(298): woocommerce_checkout_payment('')
#6 /Users/tommycrumrine/wp/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters(NU in /Users/tommycrumrine/wp/wp-content/plugins/apruve-woocommerce-master/classes/apruve_gateway.php on line 208
```